### PR TITLE
add support for Compact series devices (HPMA115C0-xxx)

### DIFF
--- a/example/example.ino
+++ b/example/example.ino
@@ -6,7 +6,7 @@
  * @license MIT
  */
 
-#include <HPMA115S0.h>
+#include <hpma115S0.h>
 #include <SoftwareSerial.h>
 
 //Create an instance of software serial

--- a/src/hpma115S0.h
+++ b/src/hpma115S0.h
@@ -13,8 +13,9 @@
 #include "Arduino.h"
 
 #define HPM_CMD_RESP_HEAD 0x40
-#define HPM_MAX_RESP_SIZE 8 // max command response size is 8 bytes
-#define HPM_READ_PARTICLE_MEASURMENT_LEN 5
+#define HPM_MAX_RESP_SIZE 8 +8 // max command response size is 8 bytes
+#define HPM_READ_PARTICLE_MEASURMENT_LEN 5         // Standard devices
+#define HPM_READ_PARTICLE_MEASURMENT_LEN_C 5 + 8   // Compact models has 8 more bytes.
 
 enum CMD_TYPE_T {
     READ_PARTICLE_MEASURMENT = 0x04,
@@ -53,8 +54,8 @@ public:
     /**
      * @brief Function that sends a read command to sensor
      * @return  returns true if valid measurements were read from sensor
-     */boolean ReadParticleMeasurement(unsigned int * pm2_5, unsigned int * pm10)
-    ;
+     */
+    boolean ReadParticleMeasurement(unsigned int * pm2_5, unsigned int * pm10);
 
     /**
      * @brief Function that starts sensor measurement
@@ -108,7 +109,7 @@ private:
      * @param size of buffer
      * @return  void
      */
-    void SendCmd(unsigned char * command, unsigned int size);
+    void SendCmd(const char * command, unsigned int size);
 
     /**
     * @brief Function that reads command response from sensor


### PR DESCRIPTION
The HPMA115C0 devices add PM1 and PM4 readings, so the message
length has changes.

Also:
  * Fix example header file name
  * Fix sendCmd function prototype to be const instead of unsigned
  * Tweak header file to fix typo around ReadParticleMeasurement

Signed-off-by: David Hunt <dave@davidhunt.ie>